### PR TITLE
fix(ci): restore mise trust step in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,7 @@ jobs:
           cache: true
 
       - run: mise install
+      - run: mise run trust
 
       - run: mise run install
 


### PR DESCRIPTION
## Summary
- restore the missing  step in 
- keep build workflow behavior consistent with publish and release workflows

## Why
The build workflow was the only workflow not trusting the repo before running mise tasks, which can fail in CI when task/config execution is gated by trust.