### PR TITLE
feat: homepage onboarding flow and AI-native software templates

### DIFF
--- a/examples/all.yaml
+++ b/examples/all.yaml
@@ -13,3 +13,4 @@ spec:
     - ./domains/*.yaml
     - ./apis/*.yaml
     - ./templates/*/template.yaml
+    - ./portal-docs/catalog-info.yaml

--- a/examples/portal-docs/catalog-info.yaml
+++ b/examples/portal-docs/catalog-info.yaml
@@ -1,0 +1,16 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: portal-docs
+  title: Developer Portal Docs
+  description: Onboarding, support, and how-to guides for the Developer Portal.
+  tags:
+    - onboarding
+    - getting-started
+    - support
+  annotations:
+    backstage.io/techdocs-ref: dir:.
+spec:
+  type: documentation
+  lifecycle: production
+  owner: group:platform-engineering

--- a/examples/portal-docs/docs/index.md
+++ b/examples/portal-docs/docs/index.md
@@ -1,0 +1,44 @@
+# Getting Started with the Developer Portal
+
+Welcome! This guide walks you through your first five minutes in the portal.
+
+## 1. Find what already exists
+
+Use the search bar on the homepage or browse the [Catalog](/catalog) to find
+services, APIs, systems, and teams. Every entity has an owner, a lifecycle,
+and links out to source code and documentation.
+
+## 2. Create your first service
+
+Head to **Start here → Create your first service** on the homepage, or go
+straight to [Self-Service](/self-service). Pick a template, fill in the form,
+and the scaffolder will:
+
+1. Create a repository in GitHub or GitLab.
+2. Seed it with a starter skeleton (code, docs, CI-ready layout).
+3. Register the new component in the catalog so it shows up immediately.
+
+## 3. Register an existing repo
+
+Already have a repository? Use
+[Catalog Import](/catalog-import) to add a `catalog-info.yaml` to it and
+register it here. Once registered it appears in search, the catalog graph,
+and your team's ownership views.
+
+## 4. Read the docs
+
+Technical documentation lives in [Docs](/docs). Anything tagged
+`onboarding` or `getting-started` is surfaced directly on the homepage.
+
+## 5. Explore APIs
+
+The [API Explorer](/api-docs) lists every API registered in the catalog,
+with OpenAPI/AsyncAPI definitions rendered inline.
+
+## What's next?
+
+- Check the **System Health** panel on the homepage for a snapshot of the
+  catalog's lifecycle states.
+- Visit the [Scorecard](/scorecard) to see how entities measure up against
+  quality checks.
+- See [Support & FAQ](support.md) if you get stuck.

--- a/examples/portal-docs/docs/support.md
+++ b/examples/portal-docs/docs/support.md
@@ -1,0 +1,43 @@
+# Support & FAQ
+
+How to get unstuck when something in the portal isn't working.
+
+## Where to get help
+
+1. **This documentation** — start with [Getting Started](index.md).
+2. **The catalog** — every entity lists an owner. For questions about a
+   specific service or API, contact the owning team shown on the entity page.
+3. **Platform Engineering** — owns the portal itself (search, scaffolder,
+   TechDocs, catalog ingestion). See the `platform-engineering` group in the
+   catalog for current members.
+
+## Frequently asked questions
+
+### My component doesn't show up in the catalog
+
+- Confirm the repo has a `catalog-info.yaml` at its root.
+- Confirm the file is registered: use
+  [Catalog Import](/catalog-import) to locate and register it.
+- Check for YAML syntax errors; a single bad entity file can be rejected by
+  the catalog ingestion loop.
+
+### My TechDocs site isn't building
+
+- Confirm the entity has the `backstage.io/techdocs-ref` annotation.
+- Confirm `mkdocs.yml` exists at the referenced path and includes the
+  `techdocs-core` plugin.
+- Docs build on first read; the first page load can take a minute.
+
+### A scaffolder run failed
+
+- Open the failed task from [Self-Service](/self-service) and expand the
+  step logs — the failing step is highlighted.
+- Most failures are permissions: the scaffolder needs a token with write
+  access to the target GitHub org or GitLab group.
+
+### How do I add a new software template?
+
+Templates live under `examples/templates/` in the portal repository. Add a
+folder with a `template.yaml` and a `template/` skeleton, tag it
+`recommended` plus a `family:` tag, and it appears on the homepage and the
+Self-Service page automatically.

--- a/examples/portal-docs/mkdocs.yml
+++ b/examples/portal-docs/mkdocs.yml
@@ -1,0 +1,9 @@
+site_name: Developer Portal Docs
+site_description: Onboarding, support, and how-to guides for the Developer Portal.
+
+nav:
+  - Getting Started: index.md
+  - Support & FAQ: support.md
+
+plugins:
+  - techdocs-core

--- a/examples/templates/ai-hub-service/template.yaml
+++ b/examples/templates/ai-hub-service/template.yaml
@@ -1,34 +1,29 @@
 apiVersion: scaffolder.backstage.io/v1beta3
 kind: Template
 metadata:
-  name: docs-blank-repo
-  title: GitLab Blank Repo
+  name: ai-hub-service
+  title: AI Hub Service
   tags:
     - recommended
-    - example
-    - gitlab
-    - family:repo
-    - provider:gitlab
+    - family:ai-native
+    - provider:github
+    - ai
+    - llm
   description: |
-    This template creates a new blank repository in GitLab.
-    It fetches a template from the local filesystem, and then publishes the result to a new repository.
+    Scaffold an AI Hub service: a thin, provider-agnostic gateway in front of
+    your organisation's LLM providers. Centralises authentication, rate
+    limiting, cost tracking, and audit logging for inference traffic.
+    Ships with an AGENTS.md, a TechDocs site, and catalog registration.
 spec:
-  owner: frontend-ninjas
-  type: sevice
+  owner: platform-engineering
+  type: service
 
   parameters:
-    - title: Fill in some steps
+    - title: Service details
       required:
         - owner
+        - name
       properties:
-        name:
-          title: Name
-          type: string
-          description: Unique name of the component
-          ui:autofocus: true
-          ui:options:
-            rows: 5
-
         owner:
           title: Owner
           type: string
@@ -37,6 +32,15 @@ spec:
           ui:options:
             catalogFilter:
               kind: [Group, User]
+        name:
+          title: Name
+          type: string
+          description: Unique name of the service
+          ui:placeholder: ai-hub
+        description:
+          title: Description
+          type: string
+          description: What this AI Hub fronts (providers, teams, use cases)
 
     - title: Choose a location
       required:
@@ -45,32 +49,36 @@ spec:
         repoUrl:
           title: Repository Location
           type: string
-          host: gitlab.com
           ui:field: RepoUrlPicker
           ui:options:
             requestUserCredentials:
               secretsKey: USER_OAUTH_TOKEN
             allowedHosts:
-              - gitlab.com
+              - github.com
             allowedOwners:
-              - echohello
+              - echohello-dev
+            allowedOrganizations:
+              - echohello-dev
 
   steps:
-    - id: template
-      name: Fetch Template
+    - id: fetch-base
+      name: Fetch Base
       action: fetch:template
       input:
         url: ./template
-        targetPath: ${{ parameters.targetPath }}
         values:
           name: ${{ parameters.name }}
           owner: ${{ parameters.owner }}
           destination: ${{ parameters.repoUrl | parseRepoUrl }}
+          description: ${{ parameters.description }}
 
     - id: publish
-      name: Publish to GitLab
-      action: publish:gitlab
+      name: Publish
+      action: publish:github
       input:
+        allowedHosts:
+          - github.com
+        description: ${{ parameters.description }}
         repoUrl: ${{ parameters.repoUrl }}
         token: ${{ secrets.USER_OAUTH_TOKEN }}
         gitAuthorName: ${{ user.entity.metadata.name }}
@@ -82,7 +90,7 @@ spec:
       action: catalog:register
       input:
         repoContentsUrl: ${{ steps.publish.output.repoContentsUrl }}
-        catalogInfoPath: '/catalog-info.yaml'
+        catalogInfoPath: /catalog-info.yaml
 
   output:
     links:
@@ -92,6 +100,7 @@ spec:
         icon: catalog
         entityRef: ${{ steps.register.output.entityRef }}
     text:
-      - title: More information
+      - title: Next steps
         content: |
-          **Entity URL:** `${{ steps['publish'].output.remoteUrl }}`
+          Your AI Hub skeleton is ready. Wire a provider in `src/providers/`,
+          then update `AGENTS.md` with the conventions your team settles on.

--- a/examples/templates/ai-hub-service/template/AGENTS.md
+++ b/examples/templates/ai-hub-service/template/AGENTS.md
@@ -1,0 +1,27 @@
+# Agent instructions for ${{ values.name }}
+
+## What this repo is
+
+An AI Hub gateway: a single, provider-agnostic front door for LLM inference
+traffic. Provider SDKs are never called directly by consumers — everything
+goes through this service.
+
+## Commands
+
+- Build: `npm run build`
+- Run locally: `npm start` (after build), listens on `PORT` (default 8080)
+- Type-check without emitting: `npx tsc --noEmit`
+
+## Conventions
+
+- One file per provider in `src/providers/`, each exporting a
+  `complete(request): Promise<Answer>`-shaped function.
+- No provider SDK imports outside `src/providers/`.
+- No secrets in the repo. Provider credentials come from environment
+  variables only.
+- Keep request/response shapes stable; consumers depend on them.
+
+## When editing
+
+- Update `docs/` when behaviour, endpoints, or configuration change.
+- Keep this file short — move detail into `docs/` and link to it.

--- a/examples/templates/ai-hub-service/template/Dockerfile
+++ b/examples/templates/ai-hub-service/template/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:22-alpine AS build
+WORKDIR /app
+COPY package.json tsconfig.json ./
+RUN npm install
+COPY src ./src
+RUN npm run build
+
+FROM node:22-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+COPY package.json ./
+RUN npm install --omit=dev
+COPY --from=build /app/dist ./dist
+EXPOSE 8080
+CMD ["node", "dist/index.js"]

--- a/examples/templates/ai-hub-service/template/README.md
+++ b/examples/templates/ai-hub-service/template/README.md
@@ -1,0 +1,35 @@
+# ${{ values.name }}
+
+{% if values.description %}${{ values.description }}{% else %}AI Hub gateway service.{% endif %}
+
+A thin, provider-agnostic gateway in front of one or more LLM providers.
+Route inference traffic through this service so authentication, rate
+limiting, cost tracking, and audit logging live in exactly one place.
+
+## Quick start
+
+```bash
+npm install
+npm run build
+npm start
+```
+
+The server listens on `PORT` (default `8080`):
+
+- `GET /healthz` — liveness probe
+- `POST /v1/answer` — single entry point for inference requests (stubbed
+  until a provider is wired in `src/providers/`)
+
+## Layout
+
+| Path | Purpose |
+|---|---|
+| `src/index.ts` | HTTP server and route wiring |
+| `src/providers/` | One file per LLM provider (add yours here) |
+| `docs/` | TechDocs site source |
+| `AGENTS.md` | Repo instructions for AI coding tools |
+
+## Documentation
+
+Rendered docs are published via TechDocs — see the **Docs** tab on this
+component's page in the Developer Portal.

--- a/examples/templates/ai-hub-service/template/catalog-info.yaml
+++ b/examples/templates/ai-hub-service/template/catalog-info.yaml
@@ -1,0 +1,21 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: ${{ values.name | dump }}
+  description: >-
+    {% if values.description %}
+    ${{ values.description | dump }}
+    {% else %}
+    AI Hub gateway service
+    {% endif %}
+  tags:
+    - ai-native
+    - ai-hub
+    - llm
+  annotations:
+    github.com/project-slug: ${{ values.destination.owner + "/" + values.destination.repo }}
+    backstage.io/techdocs-ref: dir:.
+spec:
+  type: service
+  lifecycle: experimental
+  owner: ${{ values.owner | dump }}

--- a/examples/templates/ai-hub-service/template/docs/index.md
+++ b/examples/templates/ai-hub-service/template/docs/index.md
@@ -1,0 +1,32 @@
+# ${{ values.name }}
+
+{% if values.description %}${{ values.description }}{% else %}AI Hub gateway service.{% endif %}
+
+## What it does
+
+This service is the single entry point for LLM inference traffic. Consumers
+call `POST /v1/answer`; the hub handles authentication, rate limiting, cost
+tracking, and routing to the configured provider.
+
+## Endpoints
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/healthz` | Liveness probe |
+| `POST` | `/v1/answer` | Submit a prompt, receive an answer |
+
+## Configuration
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `PORT` | `8080` | Listen port |
+
+Provider credentials are read from environment variables. Never commit
+secrets to this repository.
+
+## Adding a provider
+
+1. Create `src/providers/<name>.ts` implementing the `Provider` interface
+   from `src/providers/index.ts`.
+2. Instantiate it in `src/index.ts` and route `/v1/answer` to it.
+3. Document the provider and its configuration here.

--- a/examples/templates/ai-hub-service/template/mkdocs.yml
+++ b/examples/templates/ai-hub-service/template/mkdocs.yml
@@ -1,0 +1,10 @@
+site_name: ${{ values.name | dump }}
+{% if values.description %}
+site_description: ${{ values.description | dump }}
+{% endif %}
+
+nav:
+  - Overview: index.md
+
+plugins:
+  - techdocs-core

--- a/examples/templates/ai-hub-service/template/package.json
+++ b/examples/templates/ai-hub-service/template/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "${{ values.name }}",
+  "version": "0.1.0",
+  "private": true,
+  "description": "{% if values.description %}${{ values.description }}{% else %}AI Hub gateway service{% endif %}",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/examples/templates/ai-hub-service/template/src/index.ts
+++ b/examples/templates/ai-hub-service/template/src/index.ts
@@ -1,0 +1,61 @@
+import { createServer, IncomingMessage, ServerResponse } from 'node:http';
+
+const port = Number(process.env.PORT ?? 8080);
+
+interface AnswerRequest {
+  prompt: string;
+  model?: string;
+}
+
+async function readBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+async function handleAnswer(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  const raw = await readBody(req);
+  let payload: AnswerRequest;
+  try {
+    payload = JSON.parse(raw) as AnswerRequest;
+  } catch {
+    sendJson(res, 400, { error: 'request body must be JSON' });
+    return;
+  }
+  if (!payload.prompt) {
+    sendJson(res, 400, { error: 'prompt is required' });
+    return;
+  }
+  sendJson(res, 501, {
+    error: 'no provider configured',
+    hint: 'add a provider in src/providers/ and route to it here',
+  });
+}
+
+const server = createServer((req, res) => {
+  if (req.method === 'GET' && req.url === '/healthz') {
+    sendJson(res, 200, { status: 'ok' });
+    return;
+  }
+  if (req.method === 'POST' && req.url === '/v1/answer') {
+    handleAnswer(req, res).catch(err => {
+      sendJson(res, 500, { error: String(err) });
+    });
+    return;
+  }
+  sendJson(res, 404, { error: 'not found' });
+});
+
+server.listen(port, () => {
+  console.log(`ai-hub listening on :${port}`);
+});

--- a/examples/templates/ai-hub-service/template/src/providers/index.ts
+++ b/examples/templates/ai-hub-service/template/src/providers/index.ts
@@ -1,0 +1,15 @@
+export interface AnswerRequest {
+  prompt: string;
+  model?: string;
+}
+
+export interface Answer {
+  text: string;
+  model: string;
+  provider: string;
+}
+
+export interface Provider {
+  name: string;
+  complete(request: AnswerRequest): Promise<Answer>;
+}

--- a/examples/templates/ai-hub-service/template/tsconfig.json
+++ b/examples/templates/ai-hub-service/template/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/examples/templates/answer-engine-worker/template.yaml
+++ b/examples/templates/answer-engine-worker/template.yaml
@@ -1,34 +1,29 @@
 apiVersion: scaffolder.backstage.io/v1beta3
 kind: Template
 metadata:
-  name: docs-blank-repo
-  title: GitLab Blank Repo
+  name: answer-engine-worker
+  title: Answer Engine Worker
   tags:
     - recommended
-    - example
-    - gitlab
-    - family:repo
-    - provider:gitlab
+    - family:ai-native
+    - provider:github
+    - ai
+    - rag
   description: |
-    This template creates a new blank repository in GitLab.
-    It fetches a template from the local filesystem, and then publishes the result to a new repository.
+    Scaffold an answer-engine worker: a queue consumer that picks up
+    questions, retrieves context from a document index, and produces cited
+    answers. Ships with an indexer, a query API, an AGENTS.md, a TechDocs
+    site, and catalog registration.
 spec:
-  owner: frontend-ninjas
-  type: sevice
+  owner: platform-engineering
+  type: service
 
   parameters:
-    - title: Fill in some steps
+    - title: Worker details
       required:
         - owner
+        - name
       properties:
-        name:
-          title: Name
-          type: string
-          description: Unique name of the component
-          ui:autofocus: true
-          ui:options:
-            rows: 5
-
         owner:
           title: Owner
           type: string
@@ -37,6 +32,15 @@ spec:
           ui:options:
             catalogFilter:
               kind: [Group, User]
+        name:
+          title: Name
+          type: string
+          description: Unique name of the worker
+          ui:placeholder: answer-engine
+        description:
+          title: Description
+          type: string
+          description: What this answer engine covers (sources, audience)
 
     - title: Choose a location
       required:
@@ -45,32 +49,36 @@ spec:
         repoUrl:
           title: Repository Location
           type: string
-          host: gitlab.com
           ui:field: RepoUrlPicker
           ui:options:
             requestUserCredentials:
               secretsKey: USER_OAUTH_TOKEN
             allowedHosts:
-              - gitlab.com
+              - github.com
             allowedOwners:
-              - echohello
+              - echohello-dev
+            allowedOrganizations:
+              - echohello-dev
 
   steps:
-    - id: template
-      name: Fetch Template
+    - id: fetch-base
+      name: Fetch Base
       action: fetch:template
       input:
         url: ./template
-        targetPath: ${{ parameters.targetPath }}
         values:
           name: ${{ parameters.name }}
           owner: ${{ parameters.owner }}
           destination: ${{ parameters.repoUrl | parseRepoUrl }}
+          description: ${{ parameters.description }}
 
     - id: publish
-      name: Publish to GitLab
-      action: publish:gitlab
+      name: Publish
+      action: publish:github
       input:
+        allowedHosts:
+          - github.com
+        description: ${{ parameters.description }}
         repoUrl: ${{ parameters.repoUrl }}
         token: ${{ secrets.USER_OAUTH_TOKEN }}
         gitAuthorName: ${{ user.entity.metadata.name }}
@@ -82,7 +90,7 @@ spec:
       action: catalog:register
       input:
         repoContentsUrl: ${{ steps.publish.output.repoContentsUrl }}
-        catalogInfoPath: '/catalog-info.yaml'
+        catalogInfoPath: /catalog-info.yaml
 
   output:
     links:
@@ -92,6 +100,8 @@ spec:
         icon: catalog
         entityRef: ${{ steps.register.output.entityRef }}
     text:
-      - title: More information
+      - title: Next steps
         content: |
-          **Entity URL:** `${{ steps['publish'].output.remoteUrl }}`
+          Your answer-engine skeleton is ready. Connect a queue in
+          `src/consumer.ts`, a document source in `src/indexer.ts`, and an
+          AI Hub endpoint in `src/api.ts`.

--- a/examples/templates/answer-engine-worker/template/AGENTS.md
+++ b/examples/templates/answer-engine-worker/template/AGENTS.md
@@ -1,0 +1,27 @@
+# Agent instructions for ${{ values.name }}
+
+## What this repo is
+
+An answer-engine worker: queue consumer + document indexer + query API.
+It retrieves context from an index and delegates inference to an AI Hub —
+it never calls an LLM provider directly.
+
+## Commands
+
+- Build: `npm run build`
+- Run locally: `npm start` (after build), listens on `PORT` (default 8080)
+- Type-check without emitting: `npx tsc --noEmit`
+
+## Conventions
+
+- Inference goes through the AI Hub endpoint (`AI_HUB_URL`), never through
+  provider SDKs in this repo.
+- Retrieval logic stays in `src/indexer.ts`; queue mechanics stay in
+  `src/consumer.ts`; HTTP surface stays in `src/api.ts`.
+- Answers must carry citations — an answer without sources is a bug.
+- No secrets in the repo; configuration comes from environment variables.
+
+## When editing
+
+- Update `docs/` when the pipeline, endpoints, or configuration change.
+- Keep this file short — move detail into `docs/` and link to it.

--- a/examples/templates/answer-engine-worker/template/Dockerfile
+++ b/examples/templates/answer-engine-worker/template/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:22-alpine AS build
+WORKDIR /app
+COPY package.json tsconfig.json ./
+RUN npm install
+COPY src ./src
+RUN npm run build
+
+FROM node:22-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+COPY package.json ./
+RUN npm install --omit=dev
+COPY --from=build /app/dist ./dist
+EXPOSE 8080
+CMD ["node", "dist/index.js"]

--- a/examples/templates/answer-engine-worker/template/README.md
+++ b/examples/templates/answer-engine-worker/template/README.md
@@ -1,0 +1,32 @@
+# ${{ values.name }}
+
+{% if values.description %}${{ values.description }}{% else %}Answer engine worker.{% endif %}
+
+A worker that backs an answer engine: it consumes questions from a queue,
+retrieves supporting context from a document index, and produces cited
+answers. Designed to sit behind an AI Hub for the actual inference call.
+
+## Quick start
+
+```bash
+npm install
+npm run build
+npm start
+```
+
+## Layout
+
+| Path | Purpose |
+|---|---|
+| `src/index.ts` | Entry point — starts the API and the consumer loop |
+| `src/consumer.ts` | Queue consumer — picks up question jobs |
+| `src/indexer.ts` | Document indexer — builds the retrieval index |
+| `src/api.ts` | Query API — synchronous question answering |
+| `docs/` | TechDocs site source |
+| `AGENTS.md` | Repo instructions for AI coding tools |
+
+## The pipeline
+
+```text
+question → queue → consumer → retrieve (index) → answer (AI Hub) → cited answer
+```

--- a/examples/templates/answer-engine-worker/template/catalog-info.yaml
+++ b/examples/templates/answer-engine-worker/template/catalog-info.yaml
@@ -1,0 +1,21 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: ${{ values.name | dump }}
+  description: >-
+    {% if values.description %}
+    ${{ values.description | dump }}
+    {% else %}
+    Answer engine worker
+    {% endif %}
+  tags:
+    - ai-native
+    - answer-engine
+    - rag
+  annotations:
+    github.com/project-slug: ${{ values.destination.owner + "/" + values.destination.repo }}
+    backstage.io/techdocs-ref: dir:.
+spec:
+  type: service
+  lifecycle: experimental
+  owner: ${{ values.owner | dump }}

--- a/examples/templates/answer-engine-worker/template/docs/index.md
+++ b/examples/templates/answer-engine-worker/template/docs/index.md
@@ -1,0 +1,34 @@
+# ${{ values.name }}
+
+{% if values.description %}${{ values.description }}{% else %}Answer engine worker.{% endif %}
+
+## What it does
+
+Consumes questions from a queue, retrieves supporting context from a
+document index, and produces cited answers. Inference is delegated to an
+AI Hub — this worker owns retrieval, orchestration, and citation.
+
+## Endpoints
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/healthz` | Liveness probe |
+| `POST` | `/v1/ask` | Ask a question synchronously |
+| `POST` | `/v1/index` | Add a document to the retrieval index |
+
+## Configuration
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `PORT` | `8080` | Listen port |
+| `AI_HUB_URL` | _(unset)_ | Base URL of the AI Hub used for inference |
+| `QUEUE_POLL_INTERVAL_MS` | `5000` | Queue poll interval |
+
+## Replacing the stubs
+
+- **Queue** — implement the `Queue` interface in `src/consumer.ts` against
+  your broker (SQS, Pub/Sub, Kafka).
+- **Index** — swap the in-memory index in `src/indexer.ts` for your vector
+  store or search backend.
+- **Answers** — answers must always carry citations; treat an uncited
+  answer as a bug.

--- a/examples/templates/answer-engine-worker/template/mkdocs.yml
+++ b/examples/templates/answer-engine-worker/template/mkdocs.yml
@@ -1,0 +1,10 @@
+site_name: ${{ values.name | dump }}
+{% if values.description %}
+site_description: ${{ values.description | dump }}
+{% endif %}
+
+nav:
+  - Overview: index.md
+
+plugins:
+  - techdocs-core

--- a/examples/templates/answer-engine-worker/template/package.json
+++ b/examples/templates/answer-engine-worker/template/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "${{ values.name }}",
+  "version": "0.1.0",
+  "private": true,
+  "description": "{% if values.description %}${{ values.description }}{% else %}Answer engine worker{% endif %}",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/examples/templates/answer-engine-worker/template/src/api.ts
+++ b/examples/templates/answer-engine-worker/template/src/api.ts
@@ -1,0 +1,54 @@
+import { search, IndexedDocument } from './indexer.js';
+
+export interface Question {
+  id: string;
+  text: string;
+}
+
+export interface CitedAnswer {
+  questionId: string;
+  answer: string;
+  sources: Array<{ title: string; url: string }>;
+}
+
+const aiHubUrl = process.env.AI_HUB_URL;
+
+async function callAiHub(prompt: string): Promise<string> {
+  if (!aiHubUrl) {
+    return 'AI Hub is not configured (set AI_HUB_URL). This is a stub answer.';
+  }
+  const res = await fetch(`${aiHubUrl}/v1/answer`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ prompt }),
+  });
+  if (!res.ok) {
+    throw new Error(`AI Hub responded ${res.status}`);
+  }
+  const body = (await res.json()) as { text?: string };
+  return body.text ?? '';
+}
+
+function buildPrompt(question: string, context: IndexedDocument[]): string {
+  const passages = context
+    .map(d => `# ${d.title}\n${d.content}`)
+    .join('\n\n');
+  return [
+    'Answer the question using only the context below. Cite sources.',
+    '',
+    '## Context',
+    passages || '(no context found)',
+    '',
+    `## Question\n${question}`,
+  ].join('\n');
+}
+
+export async function answer(question: Question): Promise<CitedAnswer> {
+  const context = search(question.text);
+  const text = await callAiHub(buildPrompt(question.text, context));
+  return {
+    questionId: question.id,
+    answer: text,
+    sources: context.map(d => ({ title: d.title, url: d.url })),
+  };
+}

--- a/examples/templates/answer-engine-worker/template/src/consumer.ts
+++ b/examples/templates/answer-engine-worker/template/src/consumer.ts
@@ -1,0 +1,25 @@
+import { answer, CitedAnswer, Question } from './api.js';
+
+export interface Queue {
+  receive(): Promise<Question | undefined>;
+  ack(question: Question, result: CitedAnswer): Promise<void>;
+  nack(question: Question, error: unknown): Promise<void>;
+}
+
+const pollIntervalMs = Number(process.env.QUEUE_POLL_INTERVAL_MS ?? 5000);
+
+export async function consume(queue: Queue): Promise<never> {
+  for (;;) {
+    const question = await queue.receive();
+    if (!question) {
+      await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
+      continue;
+    }
+    try {
+      const result = await answer(question);
+      await queue.ack(question, result);
+    } catch (error) {
+      await queue.nack(question, error);
+    }
+  }
+}

--- a/examples/templates/answer-engine-worker/template/src/index.ts
+++ b/examples/templates/answer-engine-worker/template/src/index.ts
@@ -1,0 +1,70 @@
+import { createServer, IncomingMessage, ServerResponse } from 'node:http';
+import { answer } from './api.js';
+import { consume, Queue } from './consumer.js';
+import { indexDocument } from './indexer.js';
+
+const port = Number(process.env.PORT ?? 8080);
+
+async function readBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+const server = createServer((req, res) => {
+  if (req.method === 'GET' && req.url === '/healthz') {
+    sendJson(res, 200, { status: 'ok' });
+    return;
+  }
+  if (req.method === 'POST' && req.url === '/v1/ask') {
+    readBody(req)
+      .then(raw => {
+        const body = JSON.parse(raw) as { question?: string };
+        if (!body.question) {
+          sendJson(res, 400, { error: 'question is required' });
+          return undefined;
+        }
+        return answer({ id: crypto.randomUUID(), text: body.question }).then(
+          result => sendJson(res, 200, result),
+        );
+      })
+      .catch(err => sendJson(res, 500, { error: String(err) }));
+    return;
+  }
+  if (req.method === 'POST' && req.url === '/v1/index') {
+    readBody(req)
+      .then(raw => {
+        const doc = JSON.parse(raw) as Parameters<typeof indexDocument>[0];
+        indexDocument(doc);
+        sendJson(res, 202, { indexed: doc.id });
+      })
+      .catch(err => sendJson(res, 400, { error: String(err) }));
+    return;
+  }
+  sendJson(res, 404, { error: 'not found' });
+});
+
+server.listen(port, () => {
+  console.log(`answer-engine listening on :${port}`);
+});
+
+const disabledQueue: Queue = {
+  receive: () => Promise.resolve(undefined),
+  ack: () => Promise.resolve(),
+  nack: (_question, error) => {
+    console.error('question failed', error);
+    return Promise.resolve();
+  },
+};
+
+consume(disabledQueue).catch(err => {
+  console.error('consumer loop exited', err);
+  process.exit(1);
+});

--- a/examples/templates/answer-engine-worker/template/src/indexer.ts
+++ b/examples/templates/answer-engine-worker/template/src/indexer.ts
@@ -1,0 +1,29 @@
+export interface IndexedDocument {
+  id: string;
+  title: string;
+  url: string;
+  content: string;
+}
+
+const documents: IndexedDocument[] = [];
+
+export function indexDocument(doc: IndexedDocument): void {
+  documents.push(doc);
+}
+
+export function search(query: string, limit = 5): IndexedDocument[] {
+  const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
+  return documents
+    .map(doc => ({
+      doc,
+      score: terms.filter(
+        t =>
+          doc.title.toLowerCase().includes(t) ||
+          doc.content.toLowerCase().includes(t),
+      ).length,
+    }))
+    .filter(hit => hit.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+    .map(hit => hit.doc);
+}

--- a/examples/templates/answer-engine-worker/template/tsconfig.json
+++ b/examples/templates/answer-engine-worker/template/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/examples/templates/github-blank-repo/template.yaml
+++ b/examples/templates/github-blank-repo/template.yaml
@@ -7,6 +7,8 @@ metadata:
     - recommended
     - example
     - github
+    - family:repo
+    - provider:github
   description: |
     This template creates a new blank repository in GitHub.
     It fetches a template from the local filesystem, and then publishes the result to a new repository.

--- a/examples/templates/github-pull-request/template.yaml
+++ b/examples/templates/github-pull-request/template.yaml
@@ -3,6 +3,13 @@ kind: Template
 metadata:
   name: github-pull-request-docs
   title: GitHub Pull Request Docs
+  tags:
+    - recommended
+    - example
+    - github
+    - techdocs
+    - family:docs
+    - provider:github
   description: |
     This template creates a new documentation site in a GitHub repository.
     It fetches a template from the local filesystem, fetches some docs from

--- a/examples/templates/gitlab-merge-request/template.yaml
+++ b/examples/templates/gitlab-merge-request/template.yaml
@@ -3,6 +3,13 @@ kind: Template
 metadata:
   name: docs-template-gitlab-merge-request
   title: Documentation Template in GitLab with Merge Request
+  tags:
+    - recommended
+    - example
+    - gitlab
+    - techdocs
+    - family:docs
+    - provider:gitlab
   description: |
     This template creates a new documentation site in a GitLab repository.
     It fetches a template from the local filesystem, fetches some docs from

--- a/examples/templates/mcp-server/template.yaml
+++ b/examples/templates/mcp-server/template.yaml
@@ -1,34 +1,29 @@
 apiVersion: scaffolder.backstage.io/v1beta3
 kind: Template
 metadata:
-  name: docs-blank-repo
-  title: GitLab Blank Repo
+  name: mcp-server
+  title: MCP Server
   tags:
     - recommended
-    - example
-    - gitlab
-    - family:repo
-    - provider:gitlab
+    - family:ai-native
+    - provider:github
+    - ai
+    - mcp
   description: |
-    This template creates a new blank repository in GitLab.
-    It fetches a template from the local filesystem, and then publishes the result to a new repository.
+    Scaffold a Model Context Protocol (MCP) server: a stdio-based tool
+    server that AI assistants connect to for domain-specific tools and
+    context. Ships with one example tool, an AGENTS.md, a TechDocs site,
+    and catalog registration.
 spec:
-  owner: frontend-ninjas
-  type: sevice
+  owner: platform-engineering
+  type: service
 
   parameters:
-    - title: Fill in some steps
+    - title: Server details
       required:
         - owner
+        - name
       properties:
-        name:
-          title: Name
-          type: string
-          description: Unique name of the component
-          ui:autofocus: true
-          ui:options:
-            rows: 5
-
         owner:
           title: Owner
           type: string
@@ -37,6 +32,15 @@ spec:
           ui:options:
             catalogFilter:
               kind: [Group, User]
+        name:
+          title: Name
+          type: string
+          description: Unique name of the MCP server
+          ui:placeholder: my-mcp-server
+        description:
+          title: Description
+          type: string
+          description: What tools and context this server exposes
 
     - title: Choose a location
       required:
@@ -45,32 +49,36 @@ spec:
         repoUrl:
           title: Repository Location
           type: string
-          host: gitlab.com
           ui:field: RepoUrlPicker
           ui:options:
             requestUserCredentials:
               secretsKey: USER_OAUTH_TOKEN
             allowedHosts:
-              - gitlab.com
+              - github.com
             allowedOwners:
-              - echohello
+              - echohello-dev
+            allowedOrganizations:
+              - echohello-dev
 
   steps:
-    - id: template
-      name: Fetch Template
+    - id: fetch-base
+      name: Fetch Base
       action: fetch:template
       input:
         url: ./template
-        targetPath: ${{ parameters.targetPath }}
         values:
           name: ${{ parameters.name }}
           owner: ${{ parameters.owner }}
           destination: ${{ parameters.repoUrl | parseRepoUrl }}
+          description: ${{ parameters.description }}
 
     - id: publish
-      name: Publish to GitLab
-      action: publish:gitlab
+      name: Publish
+      action: publish:github
       input:
+        allowedHosts:
+          - github.com
+        description: ${{ parameters.description }}
         repoUrl: ${{ parameters.repoUrl }}
         token: ${{ secrets.USER_OAUTH_TOKEN }}
         gitAuthorName: ${{ user.entity.metadata.name }}
@@ -82,7 +90,7 @@ spec:
       action: catalog:register
       input:
         repoContentsUrl: ${{ steps.publish.output.repoContentsUrl }}
-        catalogInfoPath: '/catalog-info.yaml'
+        catalogInfoPath: /catalog-info.yaml
 
   output:
     links:
@@ -92,6 +100,7 @@ spec:
         icon: catalog
         entityRef: ${{ steps.register.output.entityRef }}
     text:
-      - title: More information
+      - title: Next steps
         content: |
-          **Entity URL:** `${{ steps['publish'].output.remoteUrl }}`
+          Your MCP server skeleton is ready. Add tools in `src/index.ts`
+          with `server.registerTool(...)` and document them in `docs/`.

--- a/examples/templates/mcp-server/template/AGENTS.md
+++ b/examples/templates/mcp-server/template/AGENTS.md
@@ -1,0 +1,26 @@
+# Agent instructions for ${{ values.name }}
+
+## What this repo is
+
+A Model Context Protocol (MCP) server exposing domain tools to AI
+assistants over stdio.
+
+## Commands
+
+- Build: `npm run build`
+- Run locally: `npm start` (after build) — speaks MCP over stdio
+- Type-check without emitting: `npx tsc --noEmit`
+
+## Conventions
+
+- Every tool is registered in `src/index.ts` with `server.registerTool`.
+- Tool names are `snake_case` and scoped to this server's domain.
+- Tool descriptions are written for the model, not for humans: say what
+  the tool does, when to use it, and what it returns.
+- Keep tools stateless where possible; take everything they need as input.
+- No secrets in the repo; configuration comes from environment variables.
+
+## When editing
+
+- Update `docs/` when tools are added, removed, or change shape.
+- Keep this file short — move detail into `docs/` and link to it.

--- a/examples/templates/mcp-server/template/Dockerfile
+++ b/examples/templates/mcp-server/template/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:22-alpine AS build
+WORKDIR /app
+COPY package.json tsconfig.json ./
+RUN npm install
+COPY src ./src
+RUN npm run build
+
+FROM node:22-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+COPY package.json ./
+RUN npm install --omit=dev
+COPY --from=build /app/dist ./dist
+CMD ["node", "dist/index.js"]

--- a/examples/templates/mcp-server/template/README.md
+++ b/examples/templates/mcp-server/template/README.md
@@ -1,0 +1,36 @@
+# ${{ values.name }}
+
+{% if values.description %}${{ values.description }}{% else %}Model Context Protocol server.{% endif %}
+
+A [Model Context Protocol](https://modelcontextprotocol.io) server that AI
+assistants connect to for domain-specific tools and context.
+
+## Quick start
+
+```bash
+npm install
+npm run build
+npm start
+```
+
+The server speaks MCP over stdio. Register it with your assistant of
+choice (Claude Desktop, Claude Code, Cursor, ...) by pointing it at
+`node dist/index.js`.
+
+## Layout
+
+| Path | Purpose |
+|---|---|
+| `src/index.ts` | Server definition and tool registrations |
+| `docs/` | TechDocs site source |
+| `AGENTS.md` | Repo instructions for AI coding tools |
+
+## Adding a tool
+
+```ts
+server.registerTool(
+  'my_tool',
+  { description: 'What it does', inputSchema: { /* zod schema */ } },
+  async args => ({ content: [{ type: 'text', text: 'result' }] }),
+);
+```

--- a/examples/templates/mcp-server/template/catalog-info.yaml
+++ b/examples/templates/mcp-server/template/catalog-info.yaml
@@ -1,0 +1,20 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: ${{ values.name | dump }}
+  description: >-
+    {% if values.description %}
+    ${{ values.description | dump }}
+    {% else %}
+    Model Context Protocol server
+    {% endif %}
+  tags:
+    - ai-native
+    - mcp
+  annotations:
+    github.com/project-slug: ${{ values.destination.owner + "/" + values.destination.repo }}
+    backstage.io/techdocs-ref: dir:.
+spec:
+  type: service
+  lifecycle: experimental
+  owner: ${{ values.owner | dump }}

--- a/examples/templates/mcp-server/template/docs/index.md
+++ b/examples/templates/mcp-server/template/docs/index.md
@@ -1,0 +1,39 @@
+# ${{ values.name }}
+
+{% if values.description %}${{ values.description }}{% else %}Model Context Protocol server.{% endif %}
+
+## What it does
+
+Exposes domain tools to AI assistants over the
+[Model Context Protocol](https://modelcontextprotocol.io), using stdio
+transport.
+
+## Tools
+
+| Tool | Description |
+|---|---|
+| `ping` | Liveness check — returns server name and time |
+| `echo` | Echoes back the provided text (example tool) |
+
+## Adding a tool
+
+Register tools in `src/index.ts`:
+
+```ts
+server.registerTool(
+  'my_tool',
+  { description: 'Written for the model: what, when, returns', inputSchema: {} },
+  async args => ({ content: [{ type: 'text', text: 'result' }] }),
+);
+```
+
+Guidelines:
+
+- Tool names are `snake_case`, scoped to this server's domain.
+- Descriptions are written for the model, not humans.
+- Prefer stateless tools; pass everything needed as input.
+
+## Configuration
+
+No configuration required for the skeleton. Add environment variables here
+as tools need them — never commit secrets.

--- a/examples/templates/mcp-server/template/mkdocs.yml
+++ b/examples/templates/mcp-server/template/mkdocs.yml
@@ -1,0 +1,10 @@
+site_name: ${{ values.name | dump }}
+{% if values.description %}
+site_description: ${{ values.description | dump }}
+{% endif %}
+
+nav:
+  - Overview: index.md
+
+plugins:
+  - techdocs-core

--- a/examples/templates/mcp-server/template/package.json
+++ b/examples/templates/mcp-server/template/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "${{ values.name }}",
+  "version": "0.1.0",
+  "private": true,
+  "description": "{% if values.description %}${{ values.description }}{% else %}Model Context Protocol server{% endif %}",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "dev": "tsc -p tsconfig.json --watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/examples/templates/mcp-server/template/src/index.ts
+++ b/examples/templates/mcp-server/template/src/index.ts
@@ -1,0 +1,48 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+
+const server = new McpServer({
+  name: '${{ values.name }}',
+  version: '0.1.0',
+});
+
+server.registerTool(
+  'ping',
+  {
+    description:
+      'Check that the server is alive. Returns a pong with the server name and current time.',
+    inputSchema: {},
+  },
+  async () => ({
+    content: [
+      {
+        type: 'text',
+        text: `pong from ${{ values.name }} at ${new Date().toISOString()}`,
+      },
+    ],
+  }),
+);
+
+server.registerTool(
+  'echo',
+  {
+    description: 'Echo back the provided text. Useful as a starting point for new tools.',
+    inputSchema: {
+      text: z.string().describe('The text to echo back'),
+    },
+  },
+  async ({ text }) => ({
+    content: [{ type: 'text', text }],
+  }),
+);
+
+async function main(): Promise<void> {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch(error => {
+  console.error('server failed to start', error);
+  process.exit(1);
+});

--- a/examples/templates/mcp-server/template/tsconfig.json
+++ b/examples/templates/mcp-server/template/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/app/src/components/home/HomePage.tsx
+++ b/packages/app/src/components/home/HomePage.tsx
@@ -18,6 +18,7 @@ import TrendingUpIcon from '@mui/icons-material/TrendingUp';
 import CodeIcon from '@mui/icons-material/Code';
 import GroupsIcon from '@mui/icons-material/Groups';
 import AnnouncementIcon from '@mui/icons-material/Announcement';
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { useState, useEffect, ReactNode } from 'react';
 import Box from '@mui/material/Box';
@@ -40,8 +41,6 @@ import ListItemButton from '@mui/material/ListItemButton';
 import Avatar from '@mui/material/Avatar';
 import Paper from '@mui/material/Paper';
 import Divider from '@mui/material/Divider';
-import Alert from '@mui/material/Alert';
-import AlertTitle from '@mui/material/AlertTitle';
 import LinearProgress from '@mui/material/LinearProgress';
 import { useApi } from '@backstage/core-plugin-api';
 import { catalogApiRef } from '@backstage/plugin-catalog-react';
@@ -122,6 +121,15 @@ interface Template {
   tags: string[];
 }
 
+interface OnboardingDoc {
+  name: string;
+  title: string;
+  description: string;
+  kind: string;
+  namespace: string;
+  tags: string[];
+}
+
 interface HealthStatus {
   healthy: number;
   warning: number;
@@ -174,6 +182,7 @@ export const HomePage = () => {
   });
   const [recentEntities, setRecentEntities] = useState<RecentEntity[]>([]);
   const [templates, setTemplates] = useState<Template[]>([]);
+  const [onboardingDocs, setOnboardingDocs] = useState<OnboardingDoc[]>([]);
   const [healthStatus, setHealthStatus] = useState<HealthStatus>({
     healthy: 0,
     warning: 0,
@@ -182,6 +191,7 @@ export const HomePage = () => {
   });
   const [loadingRecent, setLoadingRecent] = useState(true);
   const [loadingTemplates, setLoadingTemplates] = useState(true);
+  const [loadingDocs, setLoadingDocs] = useState(true);
 
   useEffect(() => {
     const fetchAllData = async () => {
@@ -255,7 +265,7 @@ export const HomePage = () => {
         setLoadingRecent(false);
 
         const templateResponse = await catalogApi.getEntities({
-          filter: [{ kind: 'template' }],
+          filter: [{ kind: 'template', 'metadata.tags': 'recommended' }],
         });
         const templateList = templateResponse.items
           .slice(0, 4)
@@ -267,10 +277,28 @@ export const HomePage = () => {
           }));
         setTemplates(templateList);
         setLoadingTemplates(false);
+
+        const docsResponse = await catalogApi.getEntities({
+          filter: [
+            { kind: 'component', 'metadata.tags': 'onboarding' },
+            { kind: 'component', 'metadata.tags': 'getting-started' },
+          ],
+        });
+        const docsList = docsResponse.items.slice(0, 4).map((e: Entity) => ({
+          name: e.metadata.name,
+          title: e.metadata.title || e.metadata.name,
+          description: e.metadata.description || '',
+          kind: e.kind.toLowerCase(),
+          namespace: e.metadata.namespace || 'default',
+          tags: (e.metadata.tags as string[]) || [],
+        }));
+        setOnboardingDocs(docsList);
+        setLoadingDocs(false);
       } catch (err) {
         setStats(prev => ({ ...prev, loading: false }));
         setLoadingRecent(false);
         setLoadingTemplates(false);
+        setLoadingDocs(false);
       }
     };
 
@@ -289,24 +317,15 @@ export const HomePage = () => {
     }
   };
 
-  const quickActions = [
+  const startHereCards = [
     {
       icon: (
         <AddIcon sx={{ fontSize: 40, color: theme.palette.primary.main }} />
       ),
-      title: 'Create New',
-      description: 'Scaffold a new project from templates',
+      title: 'Create your first service',
+      description: 'Scaffold a new project from a curated template',
       path: '/self-service',
-    },
-    {
-      icon: (
-        <ImportExportIcon
-          sx={{ fontSize: 40, color: theme.palette.secondary.main }}
-        />
-      ),
-      title: 'Register Existing',
-      description: 'Import an existing component to the catalog',
-      path: '/catalog-import',
+      ariaLabel: 'Create your first service from a software template',
     },
     {
       icon: (
@@ -314,19 +333,28 @@ export const HomePage = () => {
           sx={{ fontSize: 40, color: theme.palette.info.main }}
         />
       ),
-      title: 'Browse Docs',
-      description: 'Explore technical documentation',
+      title: 'Browse the docs',
+      description: 'Read the onboarding and platform documentation',
       path: '/docs',
+      ariaLabel: 'Browse the documentation index',
     },
     {
       icon: (
-        <ApiIcon sx={{ fontSize: 40, color: theme.palette.success.main }} />
+        <ImportExportIcon
+          sx={{ fontSize: 40, color: theme.palette.secondary.main }}
+        />
       ),
-      title: 'API Explorer',
-      description: 'Discover and explore available APIs',
-      path: '/api-docs',
+      title: 'Register an existing repo',
+      description: 'Import an existing component into the catalog',
+      path: '/catalog-import',
+      ariaLabel: 'Register an existing repository in the catalog',
     },
   ];
+
+  const supportDoc = onboardingDocs.find(d => d.tags.includes('support'));
+  const supportPath = supportDoc
+    ? `/docs/${supportDoc.namespace}/${supportDoc.kind}/${supportDoc.name}`
+    : '/docs';
 
   const catalogItems = [
     {
@@ -441,14 +469,29 @@ export const HomePage = () => {
                   {template.description}
                 </Typography>
                 <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-                  {template.tags.slice(0, 3).map(tag => (
-                    <Chip
-                      key={tag}
-                      label={tag}
-                      size="small"
-                      sx={{ fontSize: '0.7rem' }}
-                    />
-                  ))}
+                  {template.tags
+                    .filter(tag => tag.startsWith('family:'))
+                    .map(tag => (
+                      <Chip
+                        key={tag}
+                        label={tag.replace('family:', '')}
+                        size="small"
+                        color="primary"
+                        variant="outlined"
+                        sx={{ fontSize: '0.7rem' }}
+                      />
+                    ))}
+                  {template.tags
+                    .filter(tag => !tag.startsWith('family:'))
+                    .slice(0, 3)
+                    .map(tag => (
+                      <Chip
+                        key={tag}
+                        label={tag}
+                        size="small"
+                        sx={{ fontSize: '0.7rem' }}
+                      />
+                    ))}
                 </Box>
               </CardContent>
             </Card>
@@ -469,6 +512,88 @@ export const HomePage = () => {
           >
             Create your first template
           </Box>
+        </Typography>
+      </Paper>
+    );
+  }
+
+  let onboardingDocsContent: ReactNode;
+  if (loadingDocs) {
+    onboardingDocsContent = (
+      <Grid container spacing={3}>
+        {[1, 2, 3, 4].map(i => (
+          <Grid item xs={12} sm={6} key={i}>
+            <Skeleton
+              variant="rectangular"
+              height={100}
+              sx={{ borderRadius: 2 }}
+            />
+          </Grid>
+        ))}
+      </Grid>
+    );
+  } else if (onboardingDocs.length > 0) {
+    onboardingDocsContent = (
+      <Grid container spacing={3}>
+        {onboardingDocs.map(doc => (
+          <Grid item xs={12} sm={6} key={doc.name}>
+            <Card
+              sx={{
+                height: '100%',
+                cursor: 'pointer',
+                transition: 'transform 0.2s, box-shadow 0.2s',
+                '&:hover': {
+                  transform: 'translateY(-2px)',
+                  boxShadow: theme.shadows[4],
+                },
+              }}
+              onClick={() =>
+                navigate(`/docs/${doc.namespace}/${doc.kind}/${doc.name}`)
+              }
+            >
+              <CardContent>
+                <Typography variant="h6" sx={{ fontWeight: 600, mb: 1 }}>
+                  {doc.title}
+                </Typography>
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{
+                    mb: 2,
+                    display: '-webkit-box',
+                    WebkitLineClamp: 2,
+                    WebkitBoxOrient: 'vertical',
+                    overflow: 'hidden',
+                  }}
+                >
+                  {doc.description}
+                </Typography>
+                <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+                  {doc.tags.slice(0, 3).map(tag => (
+                    <Chip
+                      key={tag}
+                      label={tag}
+                      size="small"
+                      sx={{ fontSize: '0.7rem' }}
+                    />
+                  ))}
+                </Box>
+              </CardContent>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+    );
+  } else {
+    onboardingDocsContent = (
+      <Paper sx={{ p: 3, textAlign: 'center' }}>
+        <InfoOutlinedIcon sx={{ fontSize: 48, color: 'text.secondary', mb: 2 }} />
+        <Typography color="text.secondary">
+          No onboarding docs tagged yet. Tag a docs entity with{' '}
+          <Box component="span" sx={{ fontWeight: 'bold' }}>
+            onboarding
+          </Box>{' '}
+          to surface it here.
         </Typography>
       </Paper>
     );
@@ -587,34 +712,6 @@ export const HomePage = () => {
           />
         </HeroSection>
 
-        <Box sx={{ mb: 4 }}>
-          <Alert
-            severity="info"
-            icon={<AnnouncementIcon />}
-            action={
-              <Button color="inherit" size="small">
-                Learn More
-              </Button>
-            }
-          >
-            <AlertTitle>Getting Started?</AlertTitle>
-            Check out our{' '}
-            <Box
-              component="span"
-              sx={{
-                fontWeight: 'bold',
-                cursor: 'pointer',
-                textDecoration: 'underline',
-              }}
-              onClick={() => navigate('/docs')}
-            >
-              documentation
-            </Box>{' '}
-            to learn how to create your first service and register it in the
-            catalog.
-          </Alert>
-        </Box>
-
         <Box sx={{ mb: 5 }}>
           <SectionHeader
             icon={
@@ -622,14 +719,15 @@ export const HomePage = () => {
                 sx={{ fontSize: 28, color: theme.palette.primary.main }}
               />
             }
-            title="Quick Actions"
+            title="Start here"
           />
           <Grid container spacing={3}>
-            {quickActions.map(action => (
-              <Grid item xs={12} sm={6} md={3} key={action.title}>
+            {startHereCards.map(action => (
+              <Grid item xs={12} sm={6} md={4} key={action.title}>
                 <QuickActionCard>
                   <CardActionArea
                     onClick={() => navigate(action.path)}
+                    aria-label={action.ariaLabel}
                     sx={{ height: '100%', p: 3 }}
                   >
                     <Box
@@ -712,6 +810,27 @@ export const HomePage = () => {
             <Box sx={{ mb: 5 }}>
               <SectionHeader
                 icon={
+                  <LibraryBooksIcon
+                    sx={{ fontSize: 28, color: theme.palette.warning.main }}
+                  />
+                }
+                title="Onboarding Docs"
+                action={
+                  <Button
+                    endIcon={<ArrowForwardIcon />}
+                    onClick={() => navigate('/docs')}
+                    aria-label="View all documentation"
+                  >
+                    All Docs
+                  </Button>
+                }
+              />
+              {onboardingDocsContent}
+            </Box>
+
+            <Box sx={{ mb: 5 }}>
+              <SectionHeader
+                icon={
                   <CodeIcon
                     sx={{ fontSize: 28, color: theme.palette.info.main }}
                   />
@@ -721,8 +840,9 @@ export const HomePage = () => {
                   <Button
                     endIcon={<ArrowForwardIcon />}
                     onClick={() => navigate('/self-service')}
+                    aria-label="See all software templates"
                   >
-                    View All
+                    See All Templates
                   </Button>
                 }
               />
@@ -937,45 +1057,44 @@ export const HomePage = () => {
             <Box sx={{ mb: 4 }}>
               <SectionHeader
                 icon={
-                  <WidgetsIcon
+                  <HelpOutlineIcon
                     sx={{ fontSize: 28, color: theme.palette.info.main }}
                   />
                 }
-                title="Quick Links"
+                title="Support & Reference"
               />
               <Paper>
                 <List disablePadding>
-                  <ListItemButton onClick={() => navigate('/scorecard')}>
+                  <ListItemButton
+                    onClick={() => navigate('/docs')}
+                    aria-label="Open the TechDocs documentation index"
+                  >
                     <ListItemIcon>
-                      <SpeedIcon color="primary" />
+                      <LibraryBooksIcon color="primary" />
                     </ListItemIcon>
                     <ListItemText
-                      primary="Scorecard"
-                      secondary="Entity quality metrics"
+                      primary="Documentation"
+                      secondary="TechDocs index"
                     />
                   </ListItemButton>
                   <Divider />
-                  <ListItemButton onClick={() => navigate('/explore')}>
+                  <ListItemButton
+                    onClick={() => navigate('/api-docs')}
+                    aria-label="Open the API explorer"
+                  >
                     <ListItemIcon>
-                      <SearchIcon color="secondary" />
+                      <ApiIcon color="secondary" />
                     </ListItemIcon>
                     <ListItemText
-                      primary="Explore"
-                      secondary="Discover tools & services"
+                      primary="API Reference"
+                      secondary="Explore available APIs"
                     />
                   </ListItemButton>
                   <Divider />
-                  <ListItemButton onClick={() => navigate('/catalog-graph')}>
-                    <ListItemIcon>
-                      <AccountTreeIcon color="info" />
-                    </ListItemIcon>
-                    <ListItemText
-                      primary="Catalog Graph"
-                      secondary="Visualize dependencies"
-                    />
-                  </ListItemButton>
-                  <Divider />
-                  <ListItemButton onClick={() => navigate('/notifications')}>
+                  <ListItemButton
+                    onClick={() => navigate('/notifications')}
+                    aria-label="Open notifications and system alerts"
+                  >
                     <ListItemIcon>
                       <AnnouncementIcon color="warning" />
                     </ListItemIcon>
@@ -984,70 +1103,21 @@ export const HomePage = () => {
                       secondary="System alerts"
                     />
                   </ListItemButton>
+                  <Divider />
+                  <ListItemButton
+                    onClick={() => navigate(supportPath)}
+                    aria-label="Get help and support documentation"
+                  >
+                    <ListItemIcon>
+                      <HelpOutlineIcon color="info" />
+                    </ListItemIcon>
+                    <ListItemText
+                      primary="Get Help"
+                      secondary="Support & FAQ"
+                    />
+                  </ListItemButton>
                 </List>
               </Paper>
-            </Box>
-
-            <Box>
-              <SectionHeader
-                icon={
-                  <InfoOutlinedIcon
-                    sx={{ fontSize: 28, color: theme.palette.text.secondary }}
-                  />
-                }
-                title="Getting Started"
-              />
-              <Card
-                sx={{
-                  bgcolor:
-                    theme.palette.mode === 'dark'
-                      ? theme.palette.grey[800]
-                      : theme.palette.grey[50],
-                }}
-              >
-                <CardContent>
-                  <Typography variant="body2" sx={{ mb: 2 }}>
-                    New to the Developer Portal? Here are some helpful
-                    resources:
-                  </Typography>
-                  <Box
-                    sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}
-                  >
-                    <Button
-                      variant="text"
-                      size="small"
-                      sx={{ justifyContent: 'flex-start' }}
-                      onClick={() => navigate('/docs')}
-                    >
-                      📚 Read the Documentation
-                    </Button>
-                    <Button
-                      variant="text"
-                      size="small"
-                      sx={{ justifyContent: 'flex-start' }}
-                      onClick={() => navigate('/self-service')}
-                    >
-                      🚀 Create Your First Service
-                    </Button>
-                    <Button
-                      variant="text"
-                      size="small"
-                      sx={{ justifyContent: 'flex-start' }}
-                      onClick={() => navigate('/catalog-import')}
-                    >
-                      📦 Register Existing Component
-                    </Button>
-                    <Button
-                      variant="text"
-                      size="small"
-                      sx={{ justifyContent: 'flex-start' }}
-                      onClick={() => navigate('/api-docs')}
-                    >
-                      🔌 Explore Available APIs
-                    </Button>
-                  </Box>
-                </CardContent>
-              </Card>
             </Box>
           </Grid>
         </Grid>


### PR DESCRIPTION
Closes #87
Closes #88

## #87 — Homepage onboarding flow

Reorients the homepage around first-use orientation without removing catalog surfaces:

- **Start here panel** (directly under the hero): three concrete first actions — create your first service (`/self-service`), browse the docs (`/docs`), register an existing repo (`/catalog-import`). Replaces both the one-line `Getting Started?` alert and the near-identical Quick Actions grid (consolidated rather than duplicated; API Explorer moved to the sidebar).
- **Onboarding Docs section**: surfaces up to 4 catalog entities tagged `onboarding` or `getting-started` as cards linking to their TechDocs pages. Skeleton loaders while loading, graceful empty state explaining the `onboarding` tag when none exist.
- **Support & Reference sidebar panel**: replaces Quick Links with Documentation, API Reference, Notifications, and Get Help. The Get Help link is entity-driven — it points at the docs of a `support`-tagged entity when one exists, falling back to `/docs`.
- **Removed** the duplicate Getting Started sidebar card (per PRD note).
- All new links carry descriptive `aria-label`s; cards stack vertically at ≤600px via the existing Grid breakpoints; no hard-coded hex, all colours via `theme.palette.*`.
- **New `portal-docs` TechDocs entity** (`examples/portal-docs/`) with Getting Started and Support & FAQ pages, tagged `onboarding` / `getting-started` / `support`, so the new sections have real content on first boot.

## #88 — Reusable software templates

- **Family/provider tagging** on all existing templates: `family:repo`, `family:docs`, `provider:github`, `provider:gitlab`; the two docs-site templates now carry `recommended` too.
- **Homepage Popular Templates** now filters to `recommended`-tagged templates and renders a family chip on each card; the action button reads "See All Templates".
- **New AI-native templates** (informed by the April 2026 CoE notes on AI-native repo patterns — every skeleton ships a concise `AGENTS.md`, TechDocs site, Dockerfile, and catalog registration):
  - `ai-hub-service` — provider-agnostic LLM gateway (`/healthz`, `/v1/answer` stub, `src/providers/` interface)
  - `answer-engine-worker` — queue consumer + document indexer + query API (`/v1/ask`, `/v1/index`), delegates inference to an AI Hub via `AI_HUB_URL`, answers always carry citations
  - `mcp-server` — stdio MCP server with `ping`/`echo` example tools (`@modelcontextprotocol/sdk`)

Template consolidation/renames from the PRD were deliberately skipped to avoid scope creep (PRD note: "leave them as-is").

## Verification

- `yarn lint` — clean
- `mise run test` — 9 passed, 1 skipped (pre-existing suite)
- All `template.yaml` / catalog YAML parse clean
- All three TS skeletons type-check clean (`tsc --noEmit`) with their declared deps

## Manual QA checklist

- [ ] `/` with no onboarding-tagged entities → Onboarding Docs shows empty state
- [ ] `/` with `portal-docs` registered → card renders, links to `/docs/default/component/portal-docs`
- [ ] GitHub Light / Dark / Legacy themes → all new sections honour theme
- [ ] Mobile ≤600px → cards stack, no horizontal scroll
- [ ] `/self-service` → Recommended group shows all 7 templates; family tags visible
- [ ] Scaffold `ai-hub-service` end-to-end → repo created, entity in catalog, TechDocs builds

## Notes

- #86 (plugin showcase for answer engine) is adjacent but not merged here — this PR ships the templates side; plugin/extension curation can stay separate.
- The two pre-existing `tsc` errors (cli tsconfig lib entry, permission module type annotation) are unrelated to this change.